### PR TITLE
Don't load SDK if localStorage unavailable or nonfunctional.

### DIFF
--- a/getSdk.js
+++ b/getSdk.js
@@ -21,6 +21,15 @@ function getSdk(options) {
     return Promise.reject(new Error('Amplitude: cannot get SDK in server side'));
   }
 
+  try {
+    // Under some circumstances, accessing window.localStorage in IE will throw exception.
+    // In iOS Safari Private mode, localStorage is accessible, but setItem throws exception.
+    window.localStorage.setItem('amplitudeLocalStorageTest', 1);
+    window.localStorage.removeItem('amplitudeLocalStorageTest');
+  } catch(e) {
+    return Promise.reject(new Error('Amplitude: localStorage not available.'));
+  }
+
   if (window.amplitude) {
     return Promise.resolve(window.amplitude);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible-plugin-amplitude",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Integrate the amplitude SDK in your fluxible application",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
In IE under certain conditions (which I could not replicate), trying to access window.localStorage throws an exception.

Also in iOS Safari Private mode, window.localStorage is accessible, but localStorage.setItem throws exception.

This change checks for both conditions. If either is true, it bails out of loading Amplitude SDK.

To test:
A) Block all cookies in Chrome, load the site. Should not be any exception from Amplitude. (this is not a perfect test case because the given error report sounds like cookies work, but localStorage doesn't)
B) Load site in iOS Safari Private mode. Should not see this exception:
[Amplitude] Error: QuotaExceededError: DOM Exception 22
